### PR TITLE
feat " 주문 생성 api 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,113 @@ feat: 포인트 결제 API 구현
 트랜잭션 커밋 후 Kafka 이벤트 발행
 fix: 포인트 잔액 음수 허용 오류 수정
 chore: docker-compose MySQL 유저 추가
+
+## 기술적 판단: Orders - Users 간 JPA 연관관계 미적용
+
+### 결정
+
+`Orders` 엔티티에서 `User` 엔티티를 `@ManyToOne`으로 연관짓지 않고 `userId`를 값으로만 저장한다.
+
+### 근거
+
+첫째, 도메인 경계 분리를 위해서다.
+`order` 도메인이 `user` 도메인에 JPA 연관관계로 묶이면 `User` 엔티티 변경 시 `Orders`에도 영향이 생긴다.
+`userId`만 저장하면 두 도메인이 독립적으로 유지되고, 마이크로서비스로 확장할 때도 유리하다.
+
+둘째, 주문 이력 보존을 위해서다.
+유저가 탈퇴(soft delete)하더라도 주문 이력은 독립적으로 보존돼야 한다.
+JPA 연관관계로 묶으면 `users` 테이블에 강하게 결합되어 이 요구사항을 처리하기 복잡해진다.
+
+셋째, 대용량 트래픽 환경에서의 성능을 고려했다.
+DB 레벨의 FK 제약은 쓰기 성능에 부담이 될 수 있다.
+애플리케이션 레벨에서 userId 유효성을 검증하는 방식으로 대체한다.
+
+### 트레이드오프
+
+JPA 연관관계가 없으므로 `User` 정보가 필요한 경우 별도 조회가 필요하다.
+또한 DB 레벨의 참조 무결성이 보장되지 않으므로 애플리케이션 레벨에서 유효성 검증을 철저히 해야 한다.
+
+## 기술적 판단: Orders - OrderProduct 간 @OneToMany 적용
+
+### 결정
+
+`Orders` 엔티티에서 `OrderProduct`를 `@OneToMany`로 연관짓는다.
+```java
+@OneToMany(mappedBy = "orders", cascade = CascadeType.ALL, orphanRemoval = true)
+private List<OrderProduct> orderProducts = new ArrayList<>();
+```
+
+### 근거
+
+첫째, OrderProduct의 생명주기가 Orders에 완전히 종속된다.
+Orders 없이 OrderProduct는 존재할 수 없고, Orders가 삭제되면 OrderProduct도 함께 삭제돼야 한다.
+`cascade = CascadeType.ALL`과 `orphanRemoval = true`로 이 생명주기를 자동으로 관리한다.
+
+둘째, 주문 상품은 항상 주문과 함께 조회된다.
+주문 상품만 단독으로 조회하는 시나리오가 없어 @OneToMany로 묶는 것이 자연스럽다.
+
+셋째, @OneToMany 미적용 시 관리 포인트가 증가한다.
+cascade와 orphanRemoval을 직접 관리해야 하고, 도메인 응집도가 낮아진다.
+
+### N+1 방지
+
+@OneToMany는 N+1 문제가 발생하기 쉬우므로 fetch join으로 방지한다.
+```java
+@Query("SELECT o FROM Orders o JOIN FETCH o.orderProducts WHERE o.id = :id")
+Optional<Orders> findByIdWithProducts(@Param("id") Long id);
+```
+
+### 트레이드오프
+
+실무에서는 @OneToMany 남용을 지양한다.
+Orders → OrderProduct는 생명주기 종속성과 항상 함께 조회되는 특성이 있어 적용을 정당화할 수 있지만,
+다른 도메인 간 관계에서는 userId처럼 값으로만 참조하는 방식을 유지한다.
+
+## 기술적 판단: menus.name unique 제약 미적용
+
+### 결정
+
+`menus` 테이블의 `name` 컬럼에 unique 제약을 적용하지 않는다.
+
+### 근거
+
+첫째, soft delete 구조에서 unique 제약이 충돌한다.
+삭제된 메뉴(`deleted = true`)와 같은 이름의 메뉴를 재등록할 때 unique 제약 위반이 발생한다.
+조건부 unique로 우회할 수 있으나 `deleted = true`인 행이 여러 개 생기면 동일한 문제가 반복된다.
+
+둘째, 명시적인 요구사항이 없다.
+현재 요구사항에 메뉴 이름의 고유성을 강제해야 한다는 조건이 없다.
+불필요한 제약은 추후 요구사항 변경 시 오히려 장애물이 될 수 있다.
+
+셋째, 이름 중복이 필요한 시나리오가 존재한다.
+동일한 메뉴명에 옵션이나 사이즈가 추가되는 경우 이름이 겹칠 수 있어
+unique 제약이 비즈니스 확장을 제한할 수 있다.
+
+### 대안
+
+메뉴 이름 중복 방지가 필요하다면 DB 제약 대신 애플리케이션 레벨에서 검증하는 방식을 사용한다.
+이 경우 soft delete 상태를 고려한 유연한 검증이 가능하다.
+
+## 기술적 판단: OrderMenu.quantity 타입 선택 (int)
+
+### 결정
+
+`OrderMenu` 엔티티의 `quantity` 컬럼을 래퍼 타입 `Integer` 대신 원시 타입 `int`로 관리한다.
+
+### 근거
+
+수량은 null이 허용되면 안 되는 값이다.
+수량이 없는 주문 상품은 비즈니스적으로 의미가 없으므로 null을 원천 차단하는 것이 맞다.
+
+`int`는 기본적으로 null을 허용하지 않아 `@Column(nullable = false)`의 의도와 일치한다.
+반면 `Integer`를 사용하면 null 허용 가능성이 생기고, `@NotNull` 검증을 별도로 추가해야 한다.
+
+### null 안전성 보완
+
+`int`의 기본값은 0이므로 값이 누락됐을 때 0으로 저장될 위험이 있다.
+DTO에 `@Positive` 검증을 적용해 0 이하의 값을 차단한다.
+
+```java
+@Positive(message = "수량은 0보다 커야 합니다.")
+private int quantity;
+```

--- a/src/main/java/com/example/gigacoffee/GigaCoffeeApplication.java
+++ b/src/main/java/com/example/gigacoffee/GigaCoffeeApplication.java
@@ -2,9 +2,7 @@ package com.example.gigacoffee;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class GigaCoffeeApplication {
 

--- a/src/main/java/com/example/gigacoffee/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/gigacoffee/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.example.gigacoffee.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/gigacoffee/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/gigacoffee/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
 
     // Menu
     MENU_NOT_FOUND(404, "존재하지 않는 메뉴입니다."),
-    MENU_ALREADY_DELETED(400, "이미 삭제된 메뉴입니다."),
+    MENU_ALREADY_DELETED(400, "삭제된 메뉴입니다."),
 
     // Order
     ORDER_NOT_FOUND(404, "존재하지 않는 주문입니다."),

--- a/src/main/java/com/example/gigacoffee/domain/enums/OrderStatus.java
+++ b/src/main/java/com/example/gigacoffee/domain/enums/OrderStatus.java
@@ -1,0 +1,16 @@
+package com.example.gigacoffee.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+    PENDING(0, "결제 대기"),
+    COMPLETED(1, "결제 완료"),
+    CANCELLED(2, "결제 취소");
+
+    private final int code;
+    private final String description;
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/controller/OrderController.java
@@ -1,0 +1,30 @@
+package com.example.gigacoffee.domain.order.controller;
+
+import com.example.gigacoffee.common.response.ApiResponse;
+import com.example.gigacoffee.domain.order.dto.OrderRequest;
+import com.example.gigacoffee.domain.order.dto.OrderResponse;
+import com.example.gigacoffee.domain.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+            @RequestBody @Valid OrderRequest request) {
+        // 임시 userId = 1L (JWT 구현 후 토큰에서 추출)
+        Long userId = 1L;
+        return ResponseEntity.ok(ApiResponse.ok(orderService.createOrder(userId, request)));
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/dto/OrderRequest.java
@@ -1,0 +1,16 @@
+package com.example.gigacoffee.domain.order.dto;
+
+import com.example.gigacoffee.domain.orderMenu.dto.OrderMenuRequest;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderRequest {
+
+    @NotEmpty(message = "주문 상품은 최소 1개 이상이어야 합니다.")
+    private List<OrderMenuRequest>  orderMenus;
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/dto/OrderResponse.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/dto/OrderResponse.java
@@ -1,0 +1,30 @@
+package com.example.gigacoffee.domain.order.dto;
+
+import com.example.gigacoffee.domain.enums.OrderStatus;
+import com.example.gigacoffee.domain.order.entity.Order;
+import com.example.gigacoffee.domain.orderMenu.dto.OrderMenuResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class OrderResponse {
+
+    private final Long orderId;
+    private final Long totalPrice;
+    private final OrderStatus orderStatus;
+    private final List<OrderMenuResponse> orderMenus;
+
+    private OrderResponse(Order order) {
+        this.orderId = order.getId();
+        this.totalPrice = order.getTotalPrice();
+        this.orderStatus = order.getOrderStatus();
+        this.orderMenus = order.getOrderMenus().stream()
+                .map(OrderMenuResponse::from)
+                .toList();
+    }
+
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(order);
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/entity/Order.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/entity/Order.java
@@ -1,0 +1,61 @@
+package com.example.gigacoffee.domain.order.entity;
+
+import com.example.gigacoffee.common.entity.BaseEntity;
+import com.example.gigacoffee.common.exception.BusinessException;
+import com.example.gigacoffee.common.exception.ErrorCode;
+import com.example.gigacoffee.domain.enums.OrderStatus;
+import com.example.gigacoffee.domain.orderMenu.entity.OrderMenu;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus orderStatus;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderMenu> orderMenus = new ArrayList<>();
+
+    public static Order create(Long userId, Long totalPrice) {
+        Order order = new Order();
+        order.userId = userId;
+        order.totalPrice = totalPrice;
+        order.orderStatus = OrderStatus.PENDING;
+        return order;
+    }
+
+    public void complete() {
+        this.orderStatus = OrderStatus.COMPLETED;
+    }
+
+    public void cancel() {
+        if (this.orderStatus != OrderStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_CANCELLABLE);
+        }
+        this.orderStatus = OrderStatus.CANCELLED;
+    }
+
+    public void updateTotalPrice(Long totalPrice) {
+        this.totalPrice = totalPrice;
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.example.gigacoffee.domain.order.repository;
+
+import com.example.gigacoffee.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/example/gigacoffee/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/gigacoffee/domain/order/service/OrderService.java
@@ -1,0 +1,60 @@
+package com.example.gigacoffee.domain.order.service;
+
+import com.example.gigacoffee.common.exception.BusinessException;
+import com.example.gigacoffee.common.exception.ErrorCode;
+import com.example.gigacoffee.domain.menu.entity.Menu;
+import com.example.gigacoffee.domain.menu.repository.MenuRepository;
+import com.example.gigacoffee.domain.order.dto.OrderRequest;
+import com.example.gigacoffee.domain.order.dto.OrderResponse;
+import com.example.gigacoffee.domain.order.entity.Order;
+import com.example.gigacoffee.domain.order.repository.OrderRepository;
+import com.example.gigacoffee.domain.orderMenu.dto.OrderMenuRequest;
+import com.example.gigacoffee.domain.orderMenu.entity.OrderMenu;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final MenuRepository menuRepository;
+
+    @Transactional
+    public OrderResponse createOrder(Long userId, OrderRequest request) {
+        long totalPrice = 0L;
+        List<Menu> menus = new ArrayList<>();
+
+        for (OrderMenuRequest menuRequest : request.getOrderMenus()) {
+            Menu menu = menuRepository.findById(menuRequest.getMenuId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND));
+
+            if (menu.isDeleted()) {
+                throw new BusinessException(ErrorCode.MENU_ALREADY_DELETED);
+            }
+
+            menus.add(menu);
+            totalPrice += menuRequest.getQuantity() * menu.getPrice();
+        }
+
+        Order order = Order.create(userId, totalPrice);
+
+        for (int i = 0; i < menus.size(); i++) {
+            OrderMenu orderMenu = OrderMenu.create(
+                    order,
+                    menus.get(i),
+                    request.getOrderMenus().get(i).getQuantity()
+            );
+            order.getOrderMenus().add(orderMenu);
+        }
+
+        orderRepository.save(order);
+
+        return OrderResponse.from(order);
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/orderMenu/dto/OrderMenuRequest.java
+++ b/src/main/java/com/example/gigacoffee/domain/orderMenu/dto/OrderMenuRequest.java
@@ -1,0 +1,18 @@
+package com.example.gigacoffee.domain.orderMenu.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderMenuRequest {
+
+    @NotNull(message = "메뉴 ID는 필수입니다.")
+    private Long menuId;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Positive(message = "수량은 0보다 커야 합니다.")
+    private int quantity;
+}

--- a/src/main/java/com/example/gigacoffee/domain/orderMenu/dto/OrderMenuResponse.java
+++ b/src/main/java/com/example/gigacoffee/domain/orderMenu/dto/OrderMenuResponse.java
@@ -1,0 +1,26 @@
+package com.example.gigacoffee.domain.orderMenu.dto;
+
+import com.example.gigacoffee.domain.orderMenu.entity.OrderMenu;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+@Getter
+@JsonPropertyOrder({"menuName", "unitPrice", "quantity", "subtotalPrice"})
+public class OrderMenuResponse {
+
+    private final String menuName;
+    private final Long unitPrice;
+    private final int quantity;
+    private final Long subtotalPrice;
+
+    private OrderMenuResponse(OrderMenu orderMenu) {
+        this.menuName = orderMenu.getName();
+        this.unitPrice = orderMenu.getUnitPrice();
+        this.quantity = orderMenu.getQuantity();
+        this.subtotalPrice = orderMenu.getUnitPrice() * orderMenu.getQuantity();
+    }
+
+    public static OrderMenuResponse from(OrderMenu orderMenu) {
+        return new OrderMenuResponse(orderMenu);
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/orderMenu/entity/OrderMenu.java
+++ b/src/main/java/com/example/gigacoffee/domain/orderMenu/entity/OrderMenu.java
@@ -1,0 +1,46 @@
+package com.example.gigacoffee.domain.orderMenu.entity;
+
+import com.example.gigacoffee.domain.menu.entity.Menu;
+import com.example.gigacoffee.domain.order.entity.Order;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_menus")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderMenu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Long unitPrice;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public static OrderMenu create(Order order, Menu menu, int quantity) {
+        OrderMenu orderMenu = new OrderMenu();
+        orderMenu.order = order;
+        orderMenu.menu = menu;
+        orderMenu.name = menu.getName();
+        orderMenu.unitPrice = menu.getPrice();
+        orderMenu.quantity = quantity;
+        return orderMenu;
+    }
+}

--- a/src/main/java/com/example/gigacoffee/domain/orderMenu/repository/OrderMenuRepository.java
+++ b/src/main/java/com/example/gigacoffee/domain/orderMenu/repository/OrderMenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.gigacoffee.domain.orderMenu.repository;
+
+import com.example.gigacoffee.domain.orderMenu.entity.OrderMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderMenuRepository extends JpaRepository<OrderMenu, Long> {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: GigaCoffee
+  sql:
+    init:
+      mode: always
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:gigacoffee}?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul
     username: ${DB_USERNAME:root}
@@ -15,6 +18,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+    defer-datasource-initialization: true
 
   data:
     redis:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,7 @@
+INSERT INTO menus (name, price, deleted, created_at, updated_at)
+VALUES
+    ('아메리카노', 4500, false, NOW(), NOW()),
+    ('카페라떼', 5000, false, NOW(), NOW()),
+    ('카푸치노', 5500, false, NOW(), NOW()),
+    ('에스프레소', 4000, false, NOW(), NOW()),
+    ('카라멜마키아또', 6000, false, NOW(), NOW());

--- a/src/test/java/com/example/gigacoffee/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/example/gigacoffee/domain/order/controller/OrderControllerTest.java
@@ -1,0 +1,130 @@
+package com.example.gigacoffee.domain.order.controller;
+
+import com.example.gigacoffee.common.exception.BusinessException;
+import com.example.gigacoffee.common.exception.ErrorCode;
+import com.example.gigacoffee.domain.menu.entity.Menu;
+import com.example.gigacoffee.domain.order.dto.OrderRequest;
+import com.example.gigacoffee.domain.order.dto.OrderResponse;
+import com.example.gigacoffee.domain.order.entity.Order;
+import com.example.gigacoffee.domain.order.service.OrderService;
+import com.example.gigacoffee.domain.orderMenu.dto.OrderMenuRequest;
+import com.example.gigacoffee.domain.orderMenu.entity.OrderMenu;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderController.class)
+class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OrderService orderService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("정상 주문 생성 - 200 OK와 주문 정보를 반환한다")
+    void createOrder_success() throws Exception {
+        // given
+        Order order = Order.create(1L, 9000L);
+        Menu menu = Menu.create("아메리카노", 4500L);
+        order.getOrderMenus().add(OrderMenu.create(order, menu, 2));
+        OrderResponse mockResponse = OrderResponse.from(order);
+
+        given(orderService.createOrder(eq(1L), any())).willReturn(mockResponse);
+
+        String body = objectMapper.writeValueAsString(orderRequest(List.of(orderMenuRequest(1L, 2))));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalPrice").value(9000))
+                .andExpect(jsonPath("$.data.orderStatus").value("PENDING"))
+                .andExpect(jsonPath("$.data.orderMenus[0].menuName").value("아메리카노"))
+                .andExpect(jsonPath("$.data.orderMenus[0].subtotalPrice").value(9000));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 메뉴 주문 시 404를 반환한다")
+    void createOrder_menuNotFound_returns404() throws Exception {
+        // given
+        given(orderService.createOrder(eq(1L), any()))
+                .willThrow(new BusinessException(ErrorCode.MENU_NOT_FOUND));
+
+        String body = objectMapper.writeValueAsString(orderRequest(List.of(orderMenuRequest(999L, 1))));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.MENU_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("삭제된 메뉴 주문 시 400을 반환한다")
+    void createOrder_deletedMenu_returns400() throws Exception {
+        // given
+        given(orderService.createOrder(eq(1L), any()))
+                .willThrow(new BusinessException(ErrorCode.MENU_ALREADY_DELETED));
+
+        String body = objectMapper.writeValueAsString(orderRequest(List.of(orderMenuRequest(1L, 1))));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.MENU_ALREADY_DELETED.getMessage()));
+    }
+
+    @Test
+    @DisplayName("주문 목록이 비어 있으면 400을 반환한다")
+    void createOrder_emptyOrderMenus_returns400() throws Exception {
+        // given
+        String body = objectMapper.writeValueAsString(orderRequest(List.of()));
+
+        // when & then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    private OrderMenuRequest orderMenuRequest(Long menuId, int quantity) {
+        OrderMenuRequest req = new OrderMenuRequest();
+        ReflectionTestUtils.setField(req, "menuId", menuId);
+        ReflectionTestUtils.setField(req, "quantity", quantity);
+        return req;
+    }
+
+    private OrderRequest orderRequest(List<OrderMenuRequest> items) {
+        OrderRequest req = new OrderRequest();
+        ReflectionTestUtils.setField(req, "orderMenus", items);
+        return req;
+    }
+}

--- a/src/test/java/com/example/gigacoffee/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/gigacoffee/domain/order/service/OrderServiceTest.java
@@ -1,0 +1,115 @@
+package com.example.gigacoffee.domain.order.service;
+
+import com.example.gigacoffee.common.exception.BusinessException;
+import com.example.gigacoffee.common.exception.ErrorCode;
+import com.example.gigacoffee.domain.enums.OrderStatus;
+import com.example.gigacoffee.domain.menu.entity.Menu;
+import com.example.gigacoffee.domain.menu.repository.MenuRepository;
+import com.example.gigacoffee.domain.order.dto.OrderRequest;
+import com.example.gigacoffee.domain.order.dto.OrderResponse;
+import com.example.gigacoffee.domain.order.repository.OrderRepository;
+import com.example.gigacoffee.domain.orderMenu.dto.OrderMenuRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private MenuRepository menuRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Test
+    @DisplayName("정상 주문 생성 - totalPrice와 PENDING 상태를 반환한다")
+    void createOrder_success() {
+        // given
+        Long userId = 1L;
+        Menu menu = Menu.create("아메리카노", 4500L);
+
+        OrderRequest request = orderRequest(List.of(orderMenuRequest(1L, 2)));
+
+        given(menuRepository.findById(1L)).willReturn(Optional.of(menu));
+        given(orderRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        OrderResponse response = orderService.createOrder(userId, request);
+
+        // then
+        assertThat(response.getTotalPrice()).isEqualTo(9000L);
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.getOrderMenus()).hasSize(1);
+        assertThat(response.getOrderMenus().get(0).getMenuName()).isEqualTo("아메리카노");
+        assertThat(response.getOrderMenus().get(0).getSubtotalPrice()).isEqualTo(9000L);
+
+        verify(orderRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 메뉴 주문 시 MENU_NOT_FOUND 예외를 던진다")
+    void createOrder_menuNotFound_throwsException() {
+        // given
+        Long userId = 1L;
+        Long nonExistentMenuId = 999L;
+
+        OrderRequest request = orderRequest(List.of(orderMenuRequest(nonExistentMenuId, 1)));
+
+        given(menuRepository.findById(nonExistentMenuId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(userId, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MENU_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("삭제된 메뉴 주문 시 MENU_ALREADY_DELETED 예외를 던진다")
+    void createOrder_deletedMenu_throwsException() {
+        // given
+        Long userId = 1L;
+        Menu deletedMenu = Menu.create("아메리카노", 4500L);
+        deletedMenu.delete();
+
+        OrderRequest request = orderRequest(List.of(orderMenuRequest(1L, 1)));
+
+        given(menuRepository.findById(1L)).willReturn(Optional.of(deletedMenu));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrder(userId, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.MENU_ALREADY_DELETED));
+    }
+
+    private OrderMenuRequest orderMenuRequest(Long menuId, int quantity) {
+        OrderMenuRequest req = new OrderMenuRequest();
+        ReflectionTestUtils.setField(req, "menuId", menuId);
+        ReflectionTestUtils.setField(req, "quantity", quantity);
+        return req;
+    }
+
+    private OrderRequest orderRequest(List<OrderMenuRequest> items) {
+        OrderRequest req = new OrderRequest();
+        ReflectionTestUtils.setField(req, "orderMenus", items);
+        return req;
+    }
+}


### PR DESCRIPTION
## 개요

<!-- 어떤 이유로 이 PR을 올리는지 간략히 설명해 주세요 -->
주문 생성 api 구현

## 작업 내용

<!-- 구현하거나 변경한 내용을 간략히 나열해 주세요 -->
- Order, OrderMenu 엔티티 구현
- Order, OrderMenu 관련 서비스, 레포지토리, dto 생성 
- 서버 재시작 시 5개 커피 메뉴 자동으로 insert 되도록 구현 (ddl-auto : create-drop)
- EnableJpaAuditing을 JpaAuditingConfig로 분리하여 @WebMvcTest가 @Configuration 클래스를 자동으로 포함하지 않도록 하여 테스트 시 충돌을 방지

## 기술적 고려사항

<!-- 구현 과정에서 고민했던 기술적 판단이나 트레이드오프가 있다면 적어주세요 -->
`OrderMenu` 엔티티의 `quantity` 컬럼을 래퍼 타입 `Integer` 대신 원시 타입 `int`로 관리한다. 수량은 null이 허용되면 안 되는 값이다. 수량이 없는 주문 상품은 비즈니스적으로 의미가 없으므로 null을 원천 차단하는 것이 맞다.

`int`는 기본적으로 null을 허용하지 않아 `@Column(nullable = false)`의 의도와 일치한다. 반면 `Integer`를 사용하면 null 허용 가능성이 생기고, `@NotNull` 검증을 별도로 추가해야 한다. `int`의 기본값은 0이므로 값이 누락됐을 때 0으로 저장될 위험이 있다. DTO에 `@Positive` 검증을 적용해 0 이하의 값을 차단한다.

## 테스트

- [x] 로컬 환경에서 정상 동작 확인

## 참고사항

<!-- 리뷰어가 알아두면 좋을 내용, 관련 이슈, 참고 자료 등을 적어주세요 -->

#Closes #5 